### PR TITLE
Fix helloworld

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,18 @@
-# Inherit from the Ubuntu Trusty image by Scaleway.
-#   This image contains some Scaleway specific scripts
-#   See https://github.com/scaleway/image-ubuntu/blob/master/14.04/Dockerfile
-FROM scaleway/ubuntu:trusty
+## -*- docker-image-name: "scaleway/ubuntu:yakkety" -*-
+FROM scaleway/ubuntu:amd64-yakkety
+# following 'FROM' lines are used dynamically thanks do the image-builder
+# which dynamically update the Dockerfile if needed.
+#FROM scaleway/ubuntu:armhf-yakkety # arch=armv7l
+#FROM scaleway/ubuntu:i386-yakkety  # arch=i386
+#FROM scaleway/ubuntu:amd64-yakkety # arch=x86_64
+#FROM scaleway/ubuntu:mips-yakkety  # arch=mips
+
 MAINTAINER Scaleway <opensource@scaleway.com> (@scaleway)
 
 
 # Prepare rootfs for image-builder.
 #   This script prevent aptitude to run services when installed
-RUN /usr/local/sbin/builder-enter
+RUN /usr/local/sbin/scw-builder-enter
 
 
 # Install packages
@@ -22,4 +27,4 @@ COPY ./patches/ /
 
 # Clean rootfs from image-builder.
 #   Revert the builder-enter script
-RUN /usr/local/sbin/builder-leave
+RUN /usr/local/sbin/scw-builder-leave

--- a/patches/root/hello.sh
+++ b/patches/root/hello.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-cowsay 'Hello World !'
+/usr/games/cowsay 'Hello World !'


### PR DESCRIPTION
Hi I just tried to build the helloworld image (on my amd64 PC) but found out the build didn't work.
This fixes `make shell` on amd64 at least.
Changed:
* wrong path to builder-enter
* based on yakkety instead of trusty because of the apt upgrade failed

Tested build on VC1M and ran the image on VC1S.

I would also remove the `apt upgrade` since it takes time and it's just a hello world so it's not that important.

Cheers